### PR TITLE
fix: bbox array type to only include 4 numbers

### DIFF
--- a/src/geo-feature.model.ts
+++ b/src/geo-feature.model.ts
@@ -296,6 +296,6 @@ export default interface CartesiusGeoFeature {
 
   geometry: GeoJSONGeometry;
 
-  bbox?: number[];
+  bbox?: [number, number, number, number];
   properties: Properties;
 }


### PR DESCRIPTION
A Bounding Box is always specified by 2 coordinates, therefore we can restrict the type to 4 entries.